### PR TITLE
Implemented kill_account and new_account_from_phrase of parity_Accoun…

### DIFF
--- a/src/api/parity_accounts.rs
+++ b/src/api/parity_accounts.rs
@@ -23,6 +23,26 @@ impl<T: Transport> Namespace<T> for ParityAccounts<T> {
 }
 
 impl<T: Transport> ParityAccounts<T> {
+    // Given an address of an account and its password
+    // Deletes the account from the parity node
+    pub fn parity_kill_account(&self, address: &Address, pwd: &str) -> CallFuture<bool, T::Out> {
+       let address = helpers::serialize(&address);
+       let pwd = helpers::serialize(&pwd);
+       CallFuture::new(
+           self.transport
+            .execute("parity_killAccount", vec![address, pwd]),
+       ) 
+    }
+    // Imports an account from a given seed/phrase
+    // Retunrs the address of the corresponding seed vinculated account
+    pub fn parity_new_account_from_phrase(&self, seed: &str, pwd: &str) -> CallFuture<Address, T::Out> {
+       let seed = helpers::serialize(&seed);
+       let pwd = helpers::serialize(&pwd);
+       CallFuture::new(
+           self.transport
+            .execute("parity_newAccountFromPhrase", vec![seed, pwd]),
+       )  
+    }
     /// Imports an account from a given secret key.
     /// Returns the address of the corresponding Sk vinculated account.
     pub fn new_account_from_secret(&self, secret: &H256, pwd: &str) -> CallFuture<Address, T::Out> {
@@ -44,6 +64,18 @@ mod tests {
     use ethereum_types::{H256, Address};
 
     use super::ParityAccounts;
+
+    rpc_test! (
+        ParityAccounts :   parity_kill_account,  &Address::from("0x9b776baeaf3896657a9ba0db5564623b3e0173e0"), "123456789"
+        => "parity_killAccount", vec![r#""0x9b776baeaf3896657a9ba0db5564623b3e0173e0""#, r#""123456789""#];
+        Value::Bool(true) => true
+    );
+
+    rpc_test! (
+        ParityAccounts :   parity_new_account_from_phrase,  "member funny cloth wrist ugly water tuition always fall recycle maze long", "123456789"
+        => "parity_newAccountFromPhrase", vec![r#""member funny cloth wrist ugly water tuition always fall recycle maze long""#, r#""123456789""#];
+        Value::String("0xE43eD16390bd419d48B09d6E2aa20203D1eF93E1".into()) => Address::from("0xE43eD16390bd419d48B09d6E2aa20203D1eF93E1")
+    );
 
     rpc_test! (
         ParityAccounts :   new_account_from_secret,  &H256::from("c6592108cc3577f6a2d6178bc6947b43db39057195802caa0120f26e39af4945"), "123456789"


### PR DESCRIPTION
…ts API. (#191)

* Currenly in progress parity_accounts API

* Creating parity_accounts namespace and implementing newAccountFromSecret

* Adding parity_accounts on mod.rs Attaching it to Web3.

* Update src/api/parity_accounts.rs

Fixing grammar

Co-Authored-By: CPerezz <37264926+CPerezz@users.noreply.github.com>

* Fixing nitpicks

* Implement kill_account and new_account_from_phrase